### PR TITLE
Change authorize.net private methods to protected

### DIFF
--- a/payment_types/shop_authorize_net_aim_payment.php
+++ b/payment_types/shop_authorize_net_aim_payment.php
@@ -144,7 +144,7 @@
 		 * Payment processing
 		 */
 
-		private function format_form_fields(&$fields)
+		protected function format_form_fields(&$fields)
 		{
 			$result = array();
 			foreach($fields as $key=>$val)
@@ -153,7 +153,7 @@
 			return implode('&', $result);
 		}
 		
-		private function post_data($endpoint, $fields)
+		protected function post_data($endpoint, $fields)
 		{
 			$poststring = array();
 
@@ -187,12 +187,12 @@
 			return $response;
 		}
 
-		private function parse_response($response)
+		protected function parse_response($response)
 		{
 			return explode("|", $response);
 		}
 
-		private function prepare_fields_log($fields)
+		protected function prepare_fields_log($fields)
 		{
 			unset($fields['x_login']);
 			unset($fields['x_tran_key']);

--- a/updates/version.dat
+++ b/updates/version.dat
@@ -1046,3 +1046,4 @@
 #1.37.8 Adds option to attach copy of invoice as PDF on order status transition notifications
 #1.37.9 Fixes PHP5 compatibility issue
 #1.37.10 Minor improvements and fixes for payment transaction logs and generic reports
+#1.37.11 Minor improvements to Authorize.net AIM class


### PR DESCRIPTION
Updating to latest version but noticed I have a few classes that I changed from core LS. I have a custom class that extends this class but the `private` methods prevent any changes. Not sure why they would need to be `private` anyway so submitting this so I don't forget.